### PR TITLE
Updating to comply with HA 2023.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This list contains all tested and known-working dehumidifiers:
 * Inventor Eva II PRO WI-FI
 * Inventor EVA ION PRO WiFi 20L
 * Midea Cube 20 ([#22](https://github.com/Hypfer/esp8266-midea-dehumidifier/issues/22))
+* Midea Cube 35 ([#29](https://github.com/Hypfer/esp8266-midea-dehumidifier/issues/29))
 * Midea Cube 50 ([#27](https://github.com/Hypfer/esp8266-midea-dehumidifier/issues/27))
 
 Additionally, there are models that technically also work but have some issues:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This list contains all tested and known-working dehumidifiers:
 * Inventor Eva II PRO WI-FI
 * Inventor EVA ION PRO WiFi 20L
 * Midea Cube 20 ([#22](https://github.com/Hypfer/esp8266-midea-dehumidifier/issues/22))
+* Midea Cube 50 ([#27](https://github.com/Hypfer/esp8266-midea-dehumidifier/issues/27))
 
 Additionally, there are models that technically also work but have some issues:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This means an alternative is to hook up directly to this serial interface and by
 This list contains all tested and known-working dehumidifiers:
 
 * Midea MAD22S1WWT
+* Comfee MDDF-16DEN7-WF
 * Comfee MDDF-20DEN7-WF
 * Inventor Eva II PRO WI-FI
 * Inventor EVA ION PRO WiFi 20L

--- a/src/esp8266-midea-dehumidifier/esp8266-midea-dehumidifier.ino
+++ b/src/esp8266-midea-dehumidifier/esp8266-midea-dehumidifier.ino
@@ -320,11 +320,11 @@ void publishAutoConfig() {
   autoconfPayload["device"] = device.as<JsonObject>();
   autoconfPayload["availability_topic"] = MQTT_TOPIC_AVAILABILITY;
   autoconfPayload["state_topic"] = MQTT_TOPIC_STATE;
-  autoconfPayload["name"] = identifier + String(" Error Code");
-  autoconfPayload["device_class"] = "humidity";
-  autoconfPayload["unit_of_measurement"] = "code";
+  autoconfPayload["name"] = "Error Code";
+  autoconfPayload["has_entity_name"] = true;
   autoconfPayload["value_template"] = "{{value_json.errorCode}}";
   autoconfPayload["unique_id"] = identifier + String("_errorCode");
+  autoconfPayload["icon"] = "mdi:alert-circle-outline";
 
   serializeJson(autoconfPayload, mqttPayload);
   mqttClient.publish(MQTT_TOPIC_AUTOCONF_ERROR_SENSOR, mqttPayload, true);


### PR DESCRIPTION
I saw your PR on the original repo and it was useful for my Midea cube!  This brings it up to date with upstream and also updated your sensor work to comply with HA 2023.8 naming.  